### PR TITLE
Automatically check AJAX headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ publish = true
 
 [dependencies]
 base64 = { version = "0.13.0" }
-bcrypt = { version = "0.9" }
+constant_time_eq = { version = "0.2.2" }
 rand   = { version = "0.8.3" }
 rocket = { version = "0.5.0-rc.2", features = ["secrets"] }

--- a/examples/minimal/Cargo.lock
+++ b/examples/minimal/Cargo.lock
@@ -18,7 +18,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
  "opaque-debug 0.3.0",
 ]
@@ -31,7 +31,7 @@ checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
- "cipher 0.3.0",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
@@ -111,17 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bcrypt"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d0faafe9e089674fc3efdb311ff5253d445c79d85d1d28bd3ace76d45e7164"
-dependencies = [
- "base64",
- "blowfish",
- "getrandom",
-]
-
-[[package]]
 name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,17 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blowfish"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32fa6a061124e37baba002e496d203e23ba3d7b73750be82dbfbc92913048a5b"
-dependencies = [
- "byteorder",
- "cipher 0.2.5",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,21 +190,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array 0.14.4",
-]
-
-[[package]]
-name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array 0.14.4",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96535642698e10693d204abac955eb269a05ea99f8363ef70ab54cfe439337"
 
 [[package]]
 name = "cookie"
@@ -271,7 +246,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -1292,10 +1267,10 @@ dependencies = [
 
 [[package]]
 name = "rocket_csrf"
-version = "0.4.0"
+version = "0.3.0"
 dependencies = [
  "base64",
- "bcrypt",
+ "constant_time_eq",
  "rand",
  "rocket",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,12 @@ pub struct Fairing {
     token_fairing: TokenFairing,
 }
 
+impl Fairing {
+    pub fn new(config: CsrfConfig) -> Self {
+        Self { token_fairing: TokenFairing::new(config) }
+    }
+}
+
 /// Fairing that sets the CSRF token cookie.
 pub struct TokenFairing {
     config: CsrfConfig,
@@ -102,6 +108,20 @@ impl CsrfConfig {
     ///
     pub fn with_private_cookies(mut self, private: bool) -> Self {
         self.private_cookies = private;
+        self
+    }
+
+    /// Set CSRF header name.
+    ///
+    pub fn with_header_name(mut self, header_name: impl Into<Cow<'static, str>>) -> Self {
+        self.header_name = header_name.into();
+        self
+    }
+
+    /// Set URI for forbidden handler
+    ///
+    pub fn with_forbidden_uri(mut self, forbidden_uri: uri::Origin<'static>) -> Self {
+        self.forbidden_uri = forbidden_uri;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use rocket::{
     fairing::{self, Fairing as RocketFairing, Info, Kind},
     http::{Cookie, Method, Status, uri},
     request::{FromRequest, Outcome},
-    route::{self, Handler},
+    route::{self, Handler, Route},
     time::{Duration, OffsetDateTime},
     Data, Request, Rocket, State,
 };
@@ -137,7 +137,13 @@ impl RocketFairing for Fairing {
     }
 
     async fn on_ignite(&self, rocket: Rocket<rocket::Build>) -> fairing::Result {
-        self.token_fairing.on_ignite(rocket).await
+        // Set config.
+        let rocket = self.token_fairing.on_ignite(rocket).await?;
+
+        // Mount handle.
+        let rank = None; // TODO
+        let route = Route::ranked(rank, Method::Get, "/", ForbiddenHandler {});
+        Ok(rocket.mount(self.token_fairing.config.forbidden_uri.clone(), [route]))
     }
 
     async fn on_request(&self, request: &mut Request<'_>, data: &mut Data<'_>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,20 @@ use rand::{distributions::Standard, Rng};
 use rocket::{
     async_trait,
     fairing::{self, Fairing as RocketFairing, Info, Kind},
-    http::{Cookie, Method, Status},
+    http::{Cookie, Method, Status, uri},
     request::{FromRequest, Outcome},
+    route::{self, Handler},
     time::{Duration, OffsetDateTime},
     Data, Request, Rocket, State,
 };
 use std::borrow::Cow;
 
+const COOKIE_NAME: &str = "csrf_token";
 const _PARAM_NAME: &str = "authenticity_token";
-const _HEADER_NAME: &str = "X-CSRF-Token";
+const HEADER_NAME: &str = "X-CSRF-Token";
 const _PARAM_META_NAME: &str = "csrf-param";
 const _TOKEN_META_NAME: &str = "csrf-token";
+const FORBIDDEN_ROUTE: &str = "/forbidden";
 
 #[derive(Debug, Clone)]
 pub struct CsrfConfig {
@@ -25,9 +28,13 @@ pub struct CsrfConfig {
     cookie_len: usize,
     /// Whether to use private cookies
     private_cookies: bool,
+    /// CSRF header name
+    header_name: Cow<'static, str>,
+    /// URI for forbidden handler
+    forbidden_uri: uri::Origin<'static>,
 }
 
-/// Fairing that sets the CSRF token cookie and checks that write requests properly provide the
+/// Fairing that sets the CSRF token cookie and verifies that write requests properly provide the
 /// CSRF token via headers for AJAX requests or form data.
 #[derive(Default)]
 pub struct Fairing {
@@ -54,9 +61,11 @@ impl Default for CsrfConfig {
         Self {
             /// Set to 6hour for default in Database Session stores.
             lifespan: Duration::days(1),
-            cookie_name: "csrf_token".into(),
+            cookie_name: COOKIE_NAME.into(),
             cookie_len: 32,
             private_cookies: true,
+            header_name: HEADER_NAME.into(),
+            forbidden_uri: uri::Origin::parse(FORBIDDEN_ROUTE).unwrap(),
         }
     }
 }
@@ -140,11 +149,43 @@ impl RocketFairing for Fairing {
             return;
         }
 
-        // TODO: 
-        // Check header if AJAX.
-        // Otherwise, check form data.
-        // Otherwise, fail.
+        // Verify the provided CSRF token.
+        // Return a forbidden status if it's invalid.
+        if !verify_csrf_token(&request).await {
+            redirect_forbidden(request).await;
+        }
     }
+}
+
+async fn verify_csrf_token(request: &Request<'_>) -> bool {
+    let config = request.guard::<&State<CsrfConfig>>().await.unwrap();
+    // Get CSRF token from session cookie.
+    if let Some(expected_token) = request.valid_csrf_token_from_session(&config) {
+        // Get provided CSRF token from header or form data.
+        if let Some(provided_token) = get_csrf_from_header(&request, &config)
+                .or_else(|| get_csrf_from_form_data(&request, &config))
+        {
+            // Verify the provided token.
+            match expected_token.verify(&provided_token) {
+                Ok(()) => true,
+                Err(VerificationFailure{}) => false,
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
+fn get_csrf_from_header(request: &Request<'_>, config: &CsrfConfig) -> Option<String> {
+    // Get provided CSRF token from header.
+    request.headers().get_one(&config.header_name).map(|t| t.to_string())
+}
+
+fn get_csrf_from_form_data(_request: &Request<'_>, _config: &CsrfConfig) -> Option<String> {
+    // TODO: Parse form data and extract CSRF token.
+    None
 }
 
 #[async_trait]
@@ -197,16 +238,16 @@ impl<'r> FromRequest<'r> for CsrfToken {
 
         match request.valid_csrf_token_from_session(&config) {
             None => Outcome::Failure((Status::Forbidden, ())),
-            Some(token) => Outcome::Success(Self(token)),
+            Some(token) => Outcome::Success(token),
         }
     }
 }
 
 trait RequestCsrf {
-    fn valid_csrf_token_from_session(&self, config: &CsrfConfig) -> Option<String> {
+    fn valid_csrf_token_from_session(&self, config: &CsrfConfig) -> Option<CsrfToken> {
         self.csrf_token_from_session(config).and_then(|raw| {
             if raw.len() >= config.cookie_len {
-                Some(raw)
+                Some(CsrfToken(raw))
             } else {
                 None
             }
@@ -228,3 +269,20 @@ impl RequestCsrf for Request<'_> {
     }
 }
 
+// Hack until [#749](https://github.com/SergioBenitez/Rocket/issues/749) is implemented.
+async fn redirect_forbidden(request: &mut Request<'_>) {
+    let config = request.guard::<&State<CsrfConfig>>().await.unwrap();
+    let uri = config.forbidden_uri.clone();
+    request.set_uri(uri);
+    request.set_method(Method::Get);
+}
+
+#[derive(Clone)]
+struct ForbiddenHandler {}
+
+#[rocket::async_trait]
+impl Handler for ForbiddenHandler {
+    async fn handle<'a>(&self, _: &'a Request<'_>, _: Data<'a>) -> route::Outcome<'a> {
+        route::Outcome::Failure(Status::Forbidden)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ impl CsrfToken {
 
 fn is_write_request(request: &Request<'_>) -> bool {
     let method = request.method();
-    [Method::Get, Method::Head, Method::Options, Method::Trace]
+    ![Method::Get, Method::Head, Method::Options, Method::Trace]
         .iter().any(|m| &method == m)
 }
 


### PR DESCRIPTION
This builds on top of #2 to automatically check CSRF headers for AJAX requests. It makes the following changes which can be cherry-picked if you don't want to include all of them:

- Adds the configuration option to have public or private CSRF cookies
- Removes redundant base64 encodings/decodings
- Instead of hashing the token, compares the token using a constant time equality check
- Adds a fairing that rejects write requests that do not set the CSRF header properly. For previous functionality of just setting the CSRF cookie, users can use the `TokenFairing` fairing. 

FYI I also have a branch `ajax-rc.1` for 0.5-rc.1 support. 