### PR TITLE
Add CsrfForm implementation

### DIFF
--- a/src/form.rs
+++ b/src/form.rs
@@ -1,0 +1,92 @@
+use rocket::{
+    async_trait,
+    data::{Data, FromData, Outcome},
+    form::{Error, Form, FromForm},
+    http::Status,
+    Request,
+};
+
+use crate::CsrfToken;
+
+pub struct CsrfForm<T>(T);
+
+impl<T> std::ops::Deref for CsrfForm<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub enum CsrfError<E> {
+    CSRFTokenInvalid,
+    Other(E),
+}
+
+struct CsrfTokenForm<'r, T> {
+    token: &'r str,
+    inner: T,
+}
+
+impl<'r, T: FromForm<'r>> FromForm<'r> for CsrfTokenForm<'r, T> {
+    type Context = (Option<&'r str>, T::Context);
+    fn init(opts: rocket::form::Options) -> Self::Context {
+        (None, T::init(opts))
+    }
+
+    fn push_value(ctxt: &mut Self::Context, field: rocket::form::ValueField<'r>) {
+        if field.name == "csrf_token" {
+            ctxt.0 = Some(field.value);
+        } else {
+            T::push_value(&mut ctxt.1, field);
+        }
+    }
+
+    fn push_data<'life0, 'life1, 'async_trait>(
+        ctxt: &'life0 mut Self::Context,
+        field: rocket::form::DataField<'r, 'life1>,
+    ) -> core::pin::Pin<
+        Box<dyn core::future::Future<Output = ()> + core::marker::Send + 'async_trait>,
+    >
+    where
+        'r: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        T::push_data(&mut ctxt.1, field)
+    }
+
+    fn finalize(ctxt: Self::Context) -> rocket::form::Result<'r, Self> {
+        let inner = T::finalize(ctxt.1)?;
+        if let Some(token) = ctxt.0 {
+            Ok(Self { token, inner })
+        } else {
+            Err(Error::validation("csrf_token is required").into())
+        }
+    }
+}
+
+#[async_trait]
+impl<'r, T: FromForm<'r>> FromData<'r> for CsrfForm<T> {
+    type Error = CsrfError<<Form<T> as FromData<'r>>::Error>;
+    async fn from_data(r: &'r Request<'_>, d: Data<'r>) -> Outcome<'r, Self> {
+        use rocket::outcome::Outcome::*;
+        let token: CsrfToken = match r.guard().await {
+            Success(t) => t,
+            Failure((s, _e)) => return Outcome::Failure((s, CsrfError::CSRFTokenInvalid)),
+            Forward(()) => return Outcome::Forward(d),
+        };
+        let form: Form<CsrfTokenForm<T>> = match Form::from_data(r, d).await {
+            Success(t) => t,
+            Failure((s, e)) => return Outcome::Failure((s, CsrfError::Other(e))),
+            Forward(d) => return Outcome::Forward(d),
+        };
+        if token.verify(form.token).is_ok() {
+            Outcome::Success(Self(form.into_inner().inner))
+        } else {
+            Outcome::Failure((Status::NotAcceptable, CsrfError::CSRFTokenInvalid))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,9 @@ use rocket::{
     form::{Form, FromForm},
     http::{Cookie, Status},
     request::{FromRequest, Outcome},
+    sentinel::resolution::DefaultSentinel,
     time::{Duration, OffsetDateTime},
-    Data, Request, Rocket, State,
+    Data, Request, Rocket, Sentinel, State,
 };
 use std::borrow::Cow;
 
@@ -147,6 +148,14 @@ impl<'r> FromRequest<'r> for CsrfToken {
             None => Outcome::Failure((Status::Forbidden, ())),
             Some(token) => Outcome::Success(Self(base64::encode(token))),
         }
+    }
+}
+
+// Implement Sentinel for CsrfToken to require CsrfConfig to be attached
+impl Sentinel for CsrfToken {
+    fn abort(rocket: &Rocket<rocket::Ignite>) -> bool {
+        // Delegate to `&State<CsrfConfig>`
+        State::<CsrfConfig>::abort(rocket)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,17 @@ use bcrypt::{hash, verify};
 use rand::{distributions::Standard, Rng};
 use rocket::{
     async_trait,
+    data::FromData,
     fairing::{self, Fairing as RocketFairing, Info, Kind},
+    form::{Form, FromForm},
     http::{Cookie, Status},
     request::{FromRequest, Outcome},
     time::{Duration, OffsetDateTime},
     Data, Request, Rocket, State,
 };
 use std::borrow::Cow;
+
+pub mod form;
 
 const BCRYPT_COST: u32 = 8;
 
@@ -86,7 +90,7 @@ impl CsrfToken {
         hash(&self.0, BCRYPT_COST).unwrap()
     }
 
-    pub fn verify(&self, form_authenticity_token: &String) -> Result<(), VerificationFailure> {
+    pub fn verify(&self, form_authenticity_token: &str) -> Result<(), VerificationFailure> {
         if verify(&self.0, form_authenticity_token).unwrap_or(false) {
             Ok(())
         } else {


### PR DESCRIPTION
This PR adds a `CsrfForm`, which is equivalent to `rocket::form::Form`, except it verifies the presence and correctness of a CSRF token, in a field named `csrf_token`. At this point, it's not possible to configure the name of the field (this might require some re-work on the Rocket side of things), although tokio task-local state could also solve this problem.